### PR TITLE
Fully-connected layer에 대한 번역어 추가

### DIFF
--- a/TRANSLATION_GUIDE.md
+++ b/TRANSLATION_GUIDE.md
@@ -27,6 +27,7 @@
 |evaluation mode|평가 모드|박정환||
 |feed data through model|데이터를 모델에 제공|||
 |Feed-forward network|순전파 신경망|박정환||
+|Fully-connected layer|Fully-connected 계층|최재원|Fully-connected에 대해서는 번역하지 않음.|
 |Generative|생성 모델|박정환|ToC의 분류명입니다.|
 |Getting Started tutorial|시작하기 튜토리얼|박정환|ToC의 Getting Started를 뜻합니다.|
 |gradient|변화도|박정환||


### PR DESCRIPTION
## 라이선스 동의
_변경해주시는 내용에 BSD 3항 라이선스가 적용됨을 동의해주셔야 합니다._<br />
_더 자세한 내용은 [기여하기 문서](https://github.com/9bow/PyTorch-tutorials-kr/blob/master/CONTRIBUTING.md)를 참고해주세요._<br />
_동의하시면 아래 `[ ]`를 `[x]`로 만들어주세요._<br />

- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## 관련 이슈 번호
_이 Pull Request와 관련있는 이슈 번호를 적어주세요._<br />
_이슈 또는 PR 번호 앞에 #을 붙이시면 제목을 바로 확인하실 수 있습니다. (예. #999 )_

- **이슈 번호**: #292 

## PR 종류
_이 PR에 해당되는 종류 앞의 `[ ]`을 `[x]`로 변경해주세요._<br />
- [ ] 오탈자를 수정하거나 번역을 개선하는 기여
- [ ] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [x] 위 종류에 포함되지 않는 기여

## PR 설명
_이 PR로 무엇이 달라지는지 대략적으로 알려주세요._

아래와 같은 이유로 인해 Fully-connected layer 의 번역어로서 Fully-connected 계층을 제안합니다.

- 현재 진행된 많은 번역이 fully-connected layer를 fully-connected 계층으로 번역하고 있습니다.
- fully-connected layer 를 완전 연결 계층으로 번역할 경우, 이미 딥러닝에 대한 지식을 갖고 있는 사람 입장에서는 어색함을, 그렇지 않은 사람 입장에서는 구체적인 그림을 그리는데 도움을 주지 못할 것으로 생각합니다. (예를 들어, completely-connected, perfectly-connected 와 같이 여러 방향의 단어를 떠올리게 해 추가적인 검색이 어려울 수 있다고 생각합니다)
- fully-connected 라는 단어에서 fully 와 connected 각 두 단어가 난이도가 높은 단어가 아닙니다.
- FC 계층과 같이 줄여 쓸 때와의 이질감을 최소화 할 수 있습니다.

논쟁이 있을 수 있는 제안으로 여겨지는데, 그러한 만큼 많은 의견 부탁 드립니다 ㅎㅎ