### PR TITLE
Transform 및 Transformation의 번역어 제안

### DIFF
--- a/TRANSLATION_GUIDE.md
+++ b/TRANSLATION_GUIDE.md
@@ -64,6 +64,7 @@
 |Tensor / Tensors|Tensor|박정환|번역하지 않음|
 |Text|텍스트|박정환|ToC의 분류명입니다.|
 |track (computation) history|연산 기록을 추적하다|박정환||
+|Transform, Transformation|변환|최재원||
 |warmstart|빠르게 시작하기|박정환|Warmstarting Model = 빠르게 모델 시작하기|
 |weight|가중치|박정환||
 |wrapper|래퍼|박정환|음차 표기|


### PR DESCRIPTION
Transform 및 Transformation의 번역어로서 "변환"의 사용을 제안합니다.

## 라이선스 동의
_변경해주시는 내용에 BSD 3항 라이선스가 적용됨을 동의해주셔야 합니다._<br />
_더 자세한 내용은 [기여하기 문서](https://github.com/9bow/PyTorch-tutorials-kr/blob/master/CONTRIBUTING.md)를 참고해주세요._<br />
_동의하시면 아래 `[ ]`를 `[x]`로 만들어주세요._<br />

- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## 관련 이슈 번호
_이 Pull Request와 관련있는 이슈 번호를 적어주세요._<br />
_이슈 또는 PR 번호 앞에 #을 붙이시면 제목을 바로 확인하실 수 있습니다. (예. #999 )_

- **이슈 번호**: #294 

## PR 종류
_이 PR에 해당되는 종류 앞의 `[ ]`을 `[x]`로 변경해주세요._<br />
- [ ] 오탈자를 수정하거나 번역을 개선하는 기여
- [ ] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [x] 위 종류에 포함되지 않는 기여

## PR 설명
_이 PR로 무엇이 달라지는지 대략적으로 알려주세요._

아래와 같은 근거와 함께 "Transform" 및 "Transformation"에 대한 번역어로서 "변환"을 제안합니다.

- 현재 공업수학, 선형대수 등 한국의 공학 수학 교과서에는 linear transform, affine transform 등을 각각 선형 변환, 아핀 변환과 같이 번역하고 있습니다.
- "변형" 이라는 번역어도 가능하지만, 행렬의 곱셈 혹은 함수의 적용에서의 맥락에서 "Transform" 은 형태를 변화시킨다는 의미보다는 (특히 선형대수적인 맥락에서) 좌표계를 변환하는 것을 의미하는 경우가 많으므로 변환이 더 적절합니다.