### PR TITLE
prototype_source/skip_param_init.rst 번역

### DIFF
--- a/prototype_source/skip_param_init.rst
+++ b/prototype_source/skip_param_init.rst
@@ -46,16 +46,16 @@
 
 :func:`torch.nn.utils.skip_init` 의 구현(참고 :ref:`Details`) 방법에 따라,
 모듈이 함수와 호환되기 위한 두 가지 요구사항이 있습니다.
-다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 스킵 기능을 선택할 수 있습니다:
+다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 스킵 기능을 선택할 수 있습니다.
 
-  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` keyword argument를 
+  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` 키워드 인자 (keyword argument)를 
   사용해야 합니다. 
 
   2. 모듈은 초기화를 제외하고 모듈의 생성자 내 매개변수 또는 버퍼 계산을 수행하지 않아야 합니다
-  (i.e. `torch.nn.init`의 함수).
+  (즉, `torch.nn.init`의 함수).
 
-다음 예시는 작성된 매개변수, 버퍼 또는 서브 모듈에 `device` keyword argument를 전달하여 지원하도록 
-모듈이 업데이트된 것을 나타냅니다:
+다음 예시는 작성된 매개변수, 버퍼 또는 서브 모듈에 `device` 키워드 인자 (keyword argument)를 전달하여 지원하도록 
+모듈이 업데이트된 것을 나타냅니다.
 
 ::
 
@@ -67,11 +67,11 @@
         super().__init__()
 
         # ==== 사례 1: 모듈 매개변수를 직접 생성합니다. ====
-        # 생성한 매개변수에 device를 전달합니다.
+        # 생성한 매개변수에 장치 (device)를 전달합니다.
         self.param1 = nn.Parameter(torch.empty((foo, bar), device=device))
         self.register_parameter('param2', nn.Parameter(torch.empty(bar, device=device)))
 
-        # meta 장치 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
+        # meta 장치 (device) 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
         # torch.nn.init의 ops 외에는 사용하지 마십시오.
         with torch.no_grad():
             nn.init.kaiming_uniform_(self.param1)
@@ -79,8 +79,8 @@
 
 
         # ==== 사례 2: 모듈의 서브 모듈을 생성합니다. ====
-        # 모든 서브 모듈은 device를 재귀적으로 전달해야 합니다.
-        # torch.nn 모듈 예시입니다.
+        # 장치 (device)를 재귀적으로 전달해야 합니다. 모든 서브 모듈 또한 해당 사항을 지원합니다.
+        # torch.nn 에 제공되는 모든 모듈의 예시입니다.
         self.fc = nn.Linear(bar, 5, device=device)
 
         # 컨테이너에도 동일하게 적용합니다.
@@ -91,7 +91,7 @@
 
 
         # ==== 사례 3: 모듈의 버퍼를 생성합니다. ====
-        # 버퍼 tensor 생성하는 동안 device를 전달합니다.
+        # 버퍼 tensor 생성하는 동안 장치 (device)를 전달합니다.
         self.register_buffer('some_buffer', torch.ones(7, device=device))
 
     ...
@@ -105,16 +105,16 @@
 
 ::
 
-    # 1. meta 장치에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
-    # meta 장치에서 no-op 동작을 합니다.
+    # 1. meta 장치 (device)에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
+    # meta 장치 (device)에서 no-op 동작을 합니다.
     m = nn.Linear(10, 5, device='meta')
 
-    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU 장치에 구현합니다.
+    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU 장치 (device)에 구현합니다.
     # 결과는 초기화되지 않은 매개 변수를 가진 모듈 인스턴스입니다.
     m.to_empty(device='cpu')
 
-모듈은 "meta" 장치로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 스토리지는 할당하지 않습니다.
-`torch.nn.init` ops는 meta 장치를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
+모듈은 "meta" 장치 (device)로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 스토리지는 할당하지 않습니다.
+`torch.nn.init` ops는 meta 장치 (device)를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
 이에 따라 매개변수 초기화 로직에서 본질적으로 건너뛰게 됩니다.
 
-:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` keyword argument를 적절히 지원하는 모듈에서만 작동합니다.
+:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` 키워드 인자 (keyword argument)를 적절히 지원하는 모듈에서만 작동합니다.

--- a/prototype_source/skip_param_init.rst
+++ b/prototype_source/skip_param_init.rst
@@ -25,7 +25,7 @@
 --------------
 
 모듈 구성 중 매개변수 초기화를 건너뛰게 되어 낭비되는 계산을 피할 수 있습니다.
-:func:`torch.nn.utils.skip_init` 함수를 사용하여 쉽게 실행할 수 있습니다.
+:func:`torch.nn.utils.skip_init` 함수를 사용하면 쉽게 건너뛰기가 가능합니다.
 ::
 
     from torch import nn
@@ -46,16 +46,16 @@
 
 :func:`torch.nn.utils.skip_init` 의 구현(참고 :ref:`Details`) 방법에 따라,
 모듈이 함수와 호환되기 위한 두 가지 요구사항이 있습니다.
-다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 스킵 기능을 선택할 수 있습니다.
+다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 건너뛰기 기능을 선택할 수 있습니다.
 
-  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` 키워드 인자 (keyword argument)를 
+  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` 키워드 인자(keyword argument)를 
   사용해야 합니다. 
 
   2. 모듈은 초기화를 제외하고 모듈의 생성자 내 매개변수 또는 버퍼 계산을 수행하지 않아야 합니다
   (즉, `torch.nn.init`의 함수).
 
-다음 예시는 작성된 매개변수, 버퍼 또는 서브 모듈에 `device` 키워드 인자 (keyword argument)를 전달하여 지원하도록 
-모듈이 업데이트된 것을 나타냅니다.
+다음은 `device` 키워드 인자가 생성된 파라미터, 버퍼, 서브모듈로 따라 전달되기 위한
+모듈 업데이트를 보여주는 예시입니다.
 
 ::
 
@@ -67,11 +67,11 @@
         super().__init__()
 
         # ==== 사례 1: 모듈 매개변수를 직접 생성합니다. ====
-        # 생성한 매개변수에 장치 (device)를 전달합니다.
+        # 생성한 매개변수에 장치(device)를 전달합니다.
         self.param1 = nn.Parameter(torch.empty((foo, bar), device=device))
         self.register_parameter('param2', nn.Parameter(torch.empty(bar, device=device)))
 
-        # meta 장치 (device) 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
+        # meta 장치 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
         # torch.nn.init의 ops 외에는 사용하지 마십시오.
         with torch.no_grad():
             nn.init.kaiming_uniform_(self.param1)
@@ -79,8 +79,8 @@
 
 
         # ==== 사례 2: 모듈의 서브 모듈을 생성합니다. ====
-        # 장치 (device)를 재귀적으로 전달해야 합니다. 모든 서브 모듈 또한 해당 사항을 지원합니다.
-        # torch.nn 에 제공되는 모든 모듈의 예시입니다.
+        # 모든 서브 모듈이 해당 사항을 지원해야 하기 때문에 장치를 재귀적으로 전달합니다.
+        # 이는 torch.nn이 제공하는 모듈들의 경우에 해당합니다.
         self.fc = nn.Linear(bar, 5, device=device)
 
         # 컨테이너에도 동일하게 적용합니다.
@@ -91,7 +91,7 @@
 
 
         # ==== 사례 3: 모듈의 버퍼를 생성합니다. ====
-        # 버퍼 tensor 생성하는 동안 장치 (device)를 전달합니다.
+        # 버퍼 tensor 생성하는 동안 장치를 전달합니다.
         self.register_buffer('some_buffer', torch.ones(7, device=device))
 
     ...
@@ -105,16 +105,16 @@
 
 ::
 
-    # 1. meta 장치 (device)에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
-    # meta 장치 (device)에서 no-op 동작을 합니다.
+    # 1. meta 장치에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
+    # meta 장치에서 no-op 동작을 합니다.
     m = nn.Linear(10, 5, device='meta')
 
-    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU 장치 (device)에 구현합니다.
+    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU 장치에 구현합니다.
     # 결과는 초기화되지 않은 매개 변수를 가진 모듈 인스턴스입니다.
     m.to_empty(device='cpu')
 
-모듈은 "meta" 장치 (device)로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 스토리지는 할당하지 않습니다.
-`torch.nn.init` ops는 meta 장치 (device)를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
+모듈은 "meta" 장치로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 저장 공간은 할당하지 않습니다.
+`torch.nn.init` ops는 meta 장치를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
 이에 따라 매개변수 초기화 로직에서 본질적으로 건너뛰게 됩니다.
 
-:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` 키워드 인자 (keyword argument)를 적절히 지원하는 모듈에서만 작동합니다.
+:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` 키워드 인자를 적절히 지원하는 모듈에서만 작동합니다.

--- a/prototype_source/skip_param_init.rst
+++ b/prototype_source/skip_param_init.rst
@@ -1,35 +1,31 @@
-Skipping Module Parameter Initialization
-========================================
+모듈 매개변수 초기화 건너뛰기
+===========================
 
-Introduction
-------------
+소개
+----
 
-When a module is created, its learnable parameters are initialized according
-to a default initialization scheme associated with the module type. For example, the `weight`
-parameter for a :class:`torch.nn.Linear` module is initialized from a
-`uniform(-1/sqrt(in_features), 1/sqrt(in_features))` distribution. If some other initialization
-scheme is desired, this has traditionally required re-initializing the parameters
-after module instantiation:
+모듈이 생성될 때, 모듈 유형과 관련된 기본 초기화 방법에 따라 학습 가능한 매개변수가 초기화됩니다.
+예를 들어, :class:`torch.nn.Linear` 모듈의 `weight` 매개변수는 
+`uniform(-1/sqrt(in_features), 1/sqrt(in_features))` 분포로 초기화됩니다.
+기존에는 다른 초기화 방법이 필요한 경우 모듈 인스턴스화 후 매개변수를 재초기화해야 했습니다.
 
 ::
 
     from torch import nn
 
-    # Initializes weight from the default distribution: uniform(-1/sqrt(10), 1/sqrt(10)).
+    # 기본 분포로 가중치를 초기화합니다: uniform(-1/sqrt(10), 1/sqrt(10)).
     m = nn.Linear(10, 5)
 
-    # Re-initialize weight from a different distribution.
+    # 다른 분포로 가중치를 재초기화합니다.
     nn.init.orthogonal_(m.weight)
 
-In this case, the initialization done during construction is wasted computation, and it may be non-trivial if
-the `weight` parameter is large.
+이 경우 구성 중 수행되는 초기화는 계산 낭비이며, `weight` 매개변수가 크면 사소한 문제가 아닐 수 있습니다.
 
-Skipping Initialization
------------------------
+초기화 건너뛰기
+--------------
 
-It is now possible to skip parameter initialization during module construction, avoiding
-wasted computation. This is easily accomplished using the :func:`torch.nn.utils.skip_init` function:
-
+모듈 구성 중 매개변수 초기화를 건너뛰게 되어 낭비되는 계산을 피할 수 있습니다.
+:func:`torch.nn.utils.skip_init` 함수를 사용하여 쉽게 실행할 수 있습니다.
 ::
 
     from torch import nn
@@ -37,31 +33,29 @@ wasted computation. This is easily accomplished using the :func:`torch.nn.utils.
 
     m = skip_init(nn.Linear, 10, 5)
 
-    # Example: Do custom, non-default parameter initialization.
+    # 예제 : 기본 이외의 매개변수 초기화를 수정하여 실행합니다.
     nn.init.orthogonal_(m.weight)
 
-This can be applied to any module that satisfies the conditions described in the
-:ref:`Updating` section below. Note that all modules provided by
-`torch.nn` satisfy these conditions and thus support skipping init.
+아래 :ref:`Updating` 섹션에 설명된 조건을 충족하는 모듈에 적용할 수 있습니다.
+`torch.nn` 에 있는 모든 모듈은 조건을 충족하기 때문에 초기화 건너뛰기를 지원하고 있습니다.
 
 .. _Updating:
 
-Updating Modules to Support Skipping Initialization
----------------------------------------------------
+초기화 건너뛰기를 위한 모듈 업데이트
+---------------------------------
 
-Due to the way :func:`torch.nn.utils.skip_init` is implemented (see :ref:`Details`), there are
-two requirements that a module must meet to be compatible with the function.
-You can opt in to the parameter initialization skipping functionality for your custom module
-simply by adhering to these requirements:
+:func:`torch.nn.utils.skip_init` 의 구현(참고 :ref:`Details`) 방법에 따라,
+모듈이 함수와 호환되기 위한 두 가지 요구사항이 있습니다.
+다음의 요구사항을 이행하면 커스텀 모듈의 매개변수 초기화 스킵 기능을 선택할 수 있습니다:
 
-  1. The module must accept a `device` kwarg in its constructor that is passed to any parameters
-  or buffers created during construction.
+  1. 모듈을 생성할 때 매개변수와 버퍼로 전달되는 모듈의 생성자 내 `device` keyword argument를 
+  사용해야 합니다. 
 
-  2. The module must not perform any computation on parameters or buffers in its constructor except
-  initialization (i.e. functions from `torch.nn.init`).
+  2. 모듈은 초기화를 제외하고 모듈의 생성자 내 매개변수 또는 버퍼 계산을 수행하지 않아야 합니다
+  (i.e. `torch.nn.init`의 함수).
 
-The following example demonstrates a module updated to support the `device`
-kwarg by passing it along to any created parameters, buffers, or submodules:
+다음 예시는 작성된 매개변수, 버퍼 또는 서브 모듈에 `device` keyword argument를 전달하여 지원하도록 
+모듈이 업데이트된 것을 나타냅니다:
 
 ::
 
@@ -72,56 +66,55 @@ kwarg by passing it along to any created parameters, buffers, or submodules:
       def __init__(self, foo, bar, device=None):
         super().__init__()
 
-        # ==== Case 1: Module creates parameters directly. ====
-        # Pass device along to any created parameters.
+        # ==== 사례 1: 모듈 매개변수를 직접 생성합니다. ====
+        # 생성한 매개변수에 device를 전달합니다.
         self.param1 = nn.Parameter(torch.empty((foo, bar), device=device))
         self.register_parameter('param2', nn.Parameter(torch.empty(bar, device=device)))
 
-        # To ensure support for the meta device, avoid using ops except those in
-        # torch.nn.init on parameters in your module's constructor.
+        # meta 장치 지원을 확실히 하기 위해 모듈의 생성자 내 매개변수에
+        # torch.nn.init의 ops 외에는 사용하지 마십시오.
         with torch.no_grad():
             nn.init.kaiming_uniform_(self.param1)
             nn.init.uniform_(self.param2)
 
 
-        # ==== Case 2: Module creates submodules. ====
-        # Pass device along recursively. All submodules will need to support
-        # them as well; this is the case for all torch.nn provided modules.
+        # ==== 사례 2: 모듈의 서브 모듈을 생성합니다. ====
+        # 모든 서브 모듈은 device를 재귀적으로 전달해야 합니다.
+        # torch.nn 모듈 예시입니다.
         self.fc = nn.Linear(bar, 5, device=device)
 
-        # This also works with containers.
+        # 컨테이너에도 동일하게 적용합니다.
         self.linears = nn.Sequential(
             nn.Linear(5, 5, device=device),
             nn.Linear(5, 1, device=device)
         )
 
 
-        # ==== Case 3: Module creates buffers. ====
-        # Pass device along during buffer tensor creation.
+        # ==== 사례 3: 모듈의 버퍼를 생성합니다. ====
+        # 버퍼 tensor 생성하는 동안 device를 전달합니다.
         self.register_buffer('some_buffer', torch.ones(7, device=device))
 
     ...
 
 .. _Details:
 
-Implementation Details
-----------------------
+구현 세부 사항
+-------------
 
-Behind the scenes, the :func:`torch.nn.utils.skip_init` function is implemented in terms of a two-step pattern:
+내부적으로 :func:`torch.nn.utils.skip_init` 함수는 2단계 패턴으로 구현됩니다.
 
 ::
 
-    # 1. Initialize module on the meta device; all torch.nn.init ops have
-    # no-op behavior on the meta device.
+    # 1. meta 장치에서 모듈을 초기화합니다; 모든 torch.nn.init ops는 
+    # meta 장치에서 no-op 동작을 합니다.
     m = nn.Linear(10, 5, device='meta')
 
-    # 2. Materialize an uninitialized (empty) form of the module on the CPU device.
-    # The result of this is a module instance with uninitialized parameters.
+    # 2. 초기화되지 않은(빈) 형태의 모듈을 CPU 장치에 구현합니다.
+    # 결과는 초기화되지 않은 매개 변수를 가진 모듈 인스턴스입니다.
     m.to_empty(device='cpu')
 
-It works by instantiating the module onto a "meta" device, which has tensor shape information
-but does not allocate any storage. The `torch.nn.init` ops are specially implemented for this meta device
-so that they have no-op behavior. This results in the parameter intialization logic being essentially skipped.
+모듈은 "meta" 장치로 인스턴스화하여 동작합니다. tensor shape 정보를 가지고 있지만 스토리지는 할당하지 않습니다.
+`torch.nn.init` ops는 meta 장치를 위해 특별히 구현되어 있고 no-op 동작을 합니다.
+이에 따라 매개변수 초기화 로직에서 본질적으로 건너뛰게 됩니다.
 
-Note that this pattern only works for modules that properly support a `device` kwarg during construction, as
-described in :ref:`Updating`.
+:ref:`Updating` 에 설명된 대로 이 패턴은 모듈 구성 중 `device` keyword argument를 적절히 지원하는 모듈에서만 작동합니다.


### PR DESCRIPTION
vscode-hanspell을 활용하여 맞춤법 검사를 진행했습니다.

## 라이선스 동의
_변경해주시는 내용에 BSD 3항 라이선스가 적용됨을 동의해주셔야 합니다._<br />
_더 자세한 내용은 [기여하기 문서](https://github.com/PyTorchKorea/tutorials-kr/blob/master/CONTRIBUTING.md)를 참고해주세요._<br />
_동의하시면 아래 `[ ]`를 `[x]`로 만들어주세요._<br />

- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## 관련 이슈 번호
_이 Pull Request와 관련있는 이슈 번호를 적어주세요._<br />
_이슈 또는 PR 번호 앞에 #을 붙이시면 제목을 바로 확인하실 수 있습니다. (예. #999 )_

- **이슈 번호**: #558 

## PR 종류
_이 PR에 해당되는 종류 앞의 `[ ]`을 `[x]`로 변경해주세요._<br />
- [ ] 오탈자를 수정하거나 번역을 개선하는 기여
- [x] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [ ] 위 종류에 포함되지 않는 기여

## PR 설명
_이 PR로 무엇이 달라지는지 대략적으로 알려주세요._
prototype_source/skip_param_init.rst 파일을 영문에서 한문으로 수정합니다.
https://tutorials.pytorch.kr/prototype/skip_param_init.html 페이지가 한글화됩니다.

* 연습용 레포에서 피드백 받은 내용입니다. (https://github.com/hyoyoung/22-tutorials-ex/pull/23)
* 피드백 내용을 반영하였습니다.
* vscode-hanspell을 활용하여 추가적으로 맞춤법 검사를 진행했습니다.
* make html-noplot 빌드하여 최종 웹화면을 확인했습니다.

* device의 번역 관련하여 매개변수로 활용되는 경우 device로 번역하지 않았으며, 
* CPU device -> CPU 장치 와 같이 의미적으로 활용되는 경우 장치로 번역하였습니다.

