### PR TITLE
docs: nn_tutorial 번역 개선 및 오탈자 수정

### DIFF
--- a/beginner_source/nn_tutorial.py
+++ b/beginner_source/nn_tutorial.py
@@ -715,7 +715,7 @@ fit(epochs, model, loss_func, opt, train_dl, valid_dl)
 #
 # ``torch.nn`` 에는 코드를 간단히 사용할 수 있는 또 다른 편리한 클래스인
 # `Sequential <https://pytorch.org/docs/stable/nn.html#torch.nn.Sequential>`_
-# 이 있습니다..
+# 이 있습니다.
 # ``Sequential`` 객체는 그 안에 포함된 각 모듈을 순차적으로 실행합니다.
 # 이것은 우리의 신경망을 작성하는 더 간단한 방법입니다.
 #

--- a/beginner_source/nn_tutorial.py
+++ b/beginner_source/nn_tutorial.py
@@ -713,7 +713,7 @@ fit(epochs, model, loss_func, opt, train_dl, valid_dl)
 # ``nn.Sequential`` 사용하기
 # ----------------------------
 #
-# ``torch.nn`` 에는 코드를 간단히 사용할 수 있는 또 다른 편리한 클래스인
+# ``torch.nn`` 에는 코드를 간단히 할 수 있는 또 다른 편리한 클래스인
 # `Sequential <https://pytorch.org/docs/stable/nn.html#torch.nn.Sequential>`_
 # 이 있습니다.
 # ``Sequential`` 객체는 그 안에 포함된 각 모듈을 순차적으로 실행합니다.


### PR DESCRIPTION
## 라이선스 동의
- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## PR 종류
- [x] 오탈자를 수정하거나 번역을 개선하는 기여
- [ ] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [ ] 위 종류에 포함되지 않는 기여

## PR 설명

| 대상 항목: [torch.nn 이 실제로 무엇인가요?/nn.Sequential 사용하기](https://tutorials.pytorch.kr/beginner/nn_tutorial.html#nn-sequential)  |
| :-: |
| <img width="772" height="125" alt="image" src="https://github.com/user-attachments/assets/e0a5c74d-4669-49db-b21c-0af1a4c30ac6" /> |

### 1) 번역 개선 (16dd04446c32ce51d4bbeac85acefa86951a6854)

[원문](https://github.com/pytorch/tutorials/blob/05c08f20a9905355a73418f7e77edfbc43df3b47/beginner_source/nn_tutorial.py#L731-L734)
> torch.nn`` has another handy class we can use to **simplify our code**: `Sequential`.

기존
> ``torch.nn`` 에는 코드를 **간단히 사용**할 수 있는 또 다른 편리한 클래스인 `Sequential`이 있습니다..

변경
> ``torch.nn`` 에는 코드를 **간단히 표현** 할 수 있는 또 다른 편리한 클래스인 `Sequential`이 있습니다.

*simplify our code* 는 '코드를 간단히 하다'는 뜻으로, '코드를 간단히 사용할 수 있다'는 표현과는 어긋납니다. 또한 '클래스가 코드를 간단히 사용하다'는 문법상 어색하여 학습자에게 혼동을 줄 수 있습니다. 원문 방향에 가깝게 변경하는 것을 제안합니다.

### 2) 오탈자 수정 (35ae107e9e3463af6857fbf57c6d5f1e81de42f1)

"`Sequential`이 있습니다.." 의 마침표 중복 문제 수정합니다.